### PR TITLE
Better terminal output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ build: test
 build-run: build
 	./go-tapbpm
 
+install: test
+	go install
+
 run:
 	go run main.go taptracker.go
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,27 +1,49 @@
 package main
 
 import (
+	"bytes"
 	"testing"
 	"time"
+
+	"github.com/gosuri/uilive"
 )
+
+func initTestWriter() *uilive.Writer {
+	testWriter := uilive.New()
+	// start listening for updates and render
+
+	testWriterBuffer := &bytes.Buffer{}
+	testWriter.Out = testWriterBuffer
+	testWriter.Start()
+	return testWriter
+}
 
 func TestHandleInputReset(t *testing.T) {
 	now := time.Now()
 	testTapTracker := tapTracker{&now, time.Minute * 1, 60}
+	testWriter := initTestWriter()
 
-	handleInput(&testTapTracker, rune(114), 0)
+	handleInput(&testTapTracker, rune(114), 0, testWriter)
 	if testTapTracker.totalTime != 0 {
 		t.Errorf("Expected totalTime to be reset to 0, got: %v", testTapTracker.totalTime)
 	}
+
+	// TODO: test output
+	testWriter.Stop()
 }
 
 func TestHandleInputTap(t *testing.T) {
 	now := time.Now()
 	testTotalTime := time.Minute * 1
 	testTapTracker := tapTracker{&now, testTotalTime, 60}
+	testWriter := initTestWriter()
 
-	handleInput(&testTapTracker, rune(5), 0)
+	handleInput(&testTapTracker, rune(5), 0, testWriter)
 	if testTapTracker.totalTime <= testTotalTime {
 		t.Errorf("Expected totalTime to be greater than %v, got: %v", testTotalTime, testTapTracker.totalTime)
 	}
+
+	// TODO: test output
+
+	testWriter.Stop()
 }

--- a/main_test.go
+++ b/main_test.go
@@ -8,16 +8,6 @@ import (
 	"github.com/gosuri/uilive"
 )
 
-func initTestWriter() *uilive.Writer {
-	testWriter := uilive.New()
-	// start listening for updates and render
-
-	testWriterBuffer := &bytes.Buffer{}
-	testWriter.Out = testWriterBuffer
-	testWriter.Start()
-	return testWriter
-}
-
 func TestHandleInputReset(t *testing.T) {
 	now := time.Now()
 	testTapTracker := tapTracker{&now, time.Minute * 1, 60}
@@ -28,7 +18,6 @@ func TestHandleInputReset(t *testing.T) {
 		t.Errorf("Expected totalTime to be reset to 0, got: %v", testTapTracker.totalTime)
 	}
 
-	// TODO: test output
 	testWriter.Stop()
 }
 
@@ -43,7 +32,17 @@ func TestHandleInputTap(t *testing.T) {
 		t.Errorf("Expected totalTime to be greater than %v, got: %v", testTotalTime, testTapTracker.totalTime)
 	}
 
-	// TODO: test output
-
 	testWriter.Stop()
+}
+
+// Helpers
+
+func initTestWriter() *uilive.Writer {
+	testWriter := uilive.New()
+	// start listening for updates and render
+
+	testWriterBuffer := &bytes.Buffer{}
+	testWriter.Out = testWriterBuffer
+	testWriter.Start()
+	return testWriter
 }

--- a/taptracker.go
+++ b/taptracker.go
@@ -30,7 +30,7 @@ func (trkr *tapTracker) tap(newTime time.Time) {
 }
 
 func (trkr *tapTracker) bpm() float64 {
-	if trkr.trackedTime == nil {
+	if trkr.trackedTime == nil || trkr.numberOfTaps == 0 {
 		return float64(0)
 	}
 

--- a/taptracker.go
+++ b/taptracker.go
@@ -23,6 +23,9 @@ func (trkr *tapTracker) tap(newTime time.Time) {
 	if prevTime != nil {
 		trkr.totalTime = trkr.totalTime + newTime.Sub(*prevTime)
 	}
+	if prevTime == nil {
+		return
+	}
 	trkr.numberOfTaps++
 }
 
@@ -30,6 +33,11 @@ func (trkr *tapTracker) bpm() float64 {
 	if trkr.trackedTime == nil {
 		return float64(0)
 	}
+
+	if trkr.numberOfTaps == 0 {
+		return trkr.totalTime.Minutes()
+	}
+
 	bpm := (float64(trkr.numberOfTaps) / trkr.totalTime.Minutes())
 	return bpm
 }

--- a/taptracker_test.go
+++ b/taptracker_test.go
@@ -15,6 +15,7 @@ func TestTapTrackerBPM(t *testing.T) {
 		{time.Now(), time.Minute * 1, 60, float64(60)},
 		{time.Now(), time.Minute * 2, 120, float64(60)},
 		{time.Now(), time.Second * 30, 60, float64(120)},
+		{time.Now(), time.Second, 0, float64(0)},
 	}
 
 	for _, testCase := range testCases {

--- a/taptracker_test.go
+++ b/taptracker_test.go
@@ -80,12 +80,18 @@ func TestTapTrackerTap(t *testing.T) {
 		t.Errorf("Expected numberOfTaps to be %v, got: %v", newTime, trkr.trackedTime)
 	}
 
-	expectedNumberOfTaps := 1
+	expectedNumberOfTaps := 0
 	if trkr.numberOfTaps != expectedNumberOfTaps {
 		t.Errorf("Expected numberOfTaps to be %v, got: %v", expectedNumberOfTaps, trkr.numberOfTaps)
 	}
 
 	if trkr.totalTime < startingTotalTime {
 		t.Errorf("Expected startingTotalTime (%v) to less than ending total time %v", startingTotalTime, trkr.numberOfTaps)
+	}
+
+	trkr.tap(newTime)
+	expectedNumberOfTaps = 1
+	if trkr.numberOfTaps != expectedNumberOfTaps {
+		t.Errorf("Expected numberOfTaps to be %v, got: %v", expectedNumberOfTaps, trkr.numberOfTaps)
 	}
 }


### PR DESCRIPTION
Instead of printing to the screen on newlines every time, display the new BPM measurement in place. Also, fix the first tap skewing too high.